### PR TITLE
Create HTML files

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,8 +1,11 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
+const storage = require('@google-cloud/storage')();
+
 admin.initializeApp(functions.config().firebase);
 
 const firestore = admin.firestore();
+
 firestore.settings({
     timestampsInSnapshots: true
 });
@@ -23,3 +26,28 @@ exports.binCounter = functions.region('us-east1').firestore.document('/bins/{doc
             console.log(err);
         });
     });
+
+// feel like there is a better way to do this.
+// exports.createFile = functions.region('us-east1').firestore.document('/bins/{documentId}')
+//     .onCreate((snap, context) => {
+//         let amphtml = snap.data().amphtml;
+//         let binid = context.params.documentId;
+//         let filename = binid + '.html';
+// 
+//         const bucket = storage.bucket('ampbin-fe479.appspot.com');
+//         const file = bucket.file(filename);
+//         return file.setMetadata({
+//             contentType: 'text/html'
+//         }).then(() => {
+//             const uploadStream = file.createWriteStream();
+//             uploadStream.on('error', (err) => {
+//                 res.send(err);
+//             }).on('finish', () => {
+//                 res.send('ok');
+//             });
+//             uploadStream.write(amphtml);
+//             uploadStream.end();
+// 
+//             return 'done';
+//         })
+// });

--- a/functions/index.js
+++ b/functions/index.js
@@ -27,27 +27,18 @@ exports.binCounter = functions.region('us-east1').firestore.document('/bins/{doc
         });
     });
 
-// feel like there is a better way to do this.
-// exports.createFile = functions.region('us-east1').firestore.document('/bins/{documentId}')
-//     .onCreate((snap, context) => {
-//         let amphtml = snap.data().amphtml;
-//         let binid = context.params.documentId;
-//         let filename = binid + '.html';
-// 
-//         const bucket = storage.bucket('ampbin-fe479.appspot.com');
-//         const file = bucket.file(filename);
-//         return file.setMetadata({
-//             contentType: 'text/html'
-//         }).then(() => {
-//             const uploadStream = file.createWriteStream();
-//             uploadStream.on('error', (err) => {
-//                 res.send(err);
-//             }).on('finish', () => {
-//                 res.send('ok');
-//             });
-//             uploadStream.write(amphtml);
-//             uploadStream.end();
-// 
-//             return 'done';
-//         })
-// });
+exports.createFile = functions.region('us-east1').firestore.document('/bins/{documentId}')
+    .onCreate((snap, context) => {
+        let amphtml = snap.data().amphtml;
+        let binid = context.params.documentId;
+        
+        const bucket = admin.storage().bucket();
+        const file = bucket.file(binid + '.html');
+
+        return file.save(amphtml, {
+                metadata: {
+                    contentType: 'text/html'
+                },
+                resumable: false
+        });
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,6 +10,7 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
+    "@google-cloud/storage": "^1.7.0",
     "firebase-admin": "~6.0.0",
     "firebase-functions": "^2.0.3"
   },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -26,7 +26,6 @@ firebase.auth().onAuthStateChanged(function(user) {
 });
 
 if(window.location.hash.length > 0) {
-    console.log("Loading bin.");
     getBin(db, window.location.hash, editor);
 }
 
@@ -53,7 +52,6 @@ var copytextbutton = document.getElementById('copytext');
 copytextbutton.onclick = function() {
     var dummy = document.createElement('textarea'),
     amphtml = editor.getValue();
-    console.log(amphtml);
     document.body.appendChild(dummy);
     dummy.value = amphtml;
     dummy.select();


### PR DESCRIPTION
The Cloud Function is triggered when the Firebase app writes to the Firestore database. When the cloud function runs, it writes the AMP HTML to Cloud Storage.

I've created a VM that has Cloud Storage mounted locally. That server is running nginx and serves the files from Cloud Storage. The sub-domain, `static.ampb.in`, is behind Cloudflare. Each request is then cached via Cloudflare for 30 days. Each subsequent request is served by Cloudflare's cache.

This will create a new issue, showing or copying the static URL. Perhaps, people should share the editor URL (from the address bar) and they can copy the static URL using the button. Or maybe add a new button, one with a **preview** icon.

[AMPb.in Example](https://static.ampb.in/PIgf9luUSyKIRV5hNjvY.html)


Closes #46 